### PR TITLE
 Fixes suggested by Anatol Belski via pecl mailing list

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,4 @@
+branches:
+  # set to master once this works
+  only:
+    - windows-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: php
+php:
+  - '7.0'
+#  - '7.1'
+#  - '7.2'
+#  - nightly
+
+branches:
+  only:
+  - master
+
+# Travis is running Ubuntu 12.04 which doesn't have package libbase58-dev
+before_install:
+  - wget https://github.com/bitcoin/libbase58/archive/v0.1.4.tar.gz -O libbase58-0.1.4.tar.gz
+  - tar -xzf libbase58-0.1.4.tar.gz
+  - pushd libbase58-0.1.4 && autoreconf --install && ./configure --prefix=/usr && make && sudo make install && popd
+
+install:
+  - phpize
+  - ./configure
+  - make
+
+before_script:
+  make install
+
+script:
+  make test
+

--- a/config.w32
+++ b/config.w32
@@ -5,7 +5,7 @@ ARG_WITH("base58", "for base58 support", "no");
 
 if (PHP_SODIUM != "no") {
     if (CHECK_LIB("libbase58.lib", "libbase58", PHP_BASE58) && CHECK_HEADER_ADD_INCLUDE("libbase58.h", "CFLAGS_BASE58")) {
-        EXTENSION("sodium", "libsodium.c");
+        EXTENSION("base58", "base58.c");
         AC_DEFINE('HAVE_BASE58', 1 , 'Have base58 support');
         PHP_INSTALL_HEADERS("ext/base58/", "php_base58.h");
     } else {

--- a/php_base58.h
+++ b/php_base58.h
@@ -1,15 +1,45 @@
+/*
+  +----------------------------------------------------------------------+
+  | Base58 PHP extension                                                 |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 2018 Stichting LegalThings One foundation              |
+  +----------------------------------------------------------------------+
+  | Permission is hereby granted, free of charge, to any person          |
+  | obtaining a copy of this software and associated documentation files |
+  | (the "Software"), to deal in the Software without restriction,       |
+  | including without limitation the rights to use, copy, modify, merge, |
+  | publish, distribute, sublicense, and/or sell copies of the Software, |
+  | and to permit persons to whom the Software is furnished to do so,    |
+  | subject to the following conditions:                                 |
+  |                                                                      |
+  | The above copyright notice and this permission notice shall be       |
+  | included in all copies or substantial portions of the Software.      |
+  |                                                                      |
+  | THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,      |
+  | EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF   |
+  | MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                |
+  | NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS  |
+  | BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN   |
+  | ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN    |
+  | CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE     |
+  | SOFTWARE.                                                            |
+  +----------------------------------------------------------------------+
+  | Author: Arnold Daniels <arnold@jasny.net>                            |
+  +----------------------------------------------------------------------+
+*/
+
 #ifndef PHP_BASE58_H
 #define PHP_BASE58_H 1
 
-#define PHP_BASE58_VERSION "0.1.0"
+#define PHP_BASE58_VERSION "0.1.2"
 #define PHP_BASE58_EXTNAME "base58"
 
 #ifdef PHP_WIN32
-# define PHP_SODIUM_API __declspec(dllexport)
+# define PHP_BASE58_API __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4
-# define PHP_SODIUM_API __attribute__ ((visibility("default")))
+# define PHP_BASE58_API __attribute__ ((visibility("default")))
 #else
-# define PHP_SODIUM_API
+# define PHP_BASE58_API
 #endif
 
 static PHP_MINFO_FUNCTION(base58);


### PR DESCRIPTION
- With RETURN_STRINGL there might be a memory leak, as it would
actually allocate a new zend_string, so the old emalloc'd pointer might
be leaked. Allocate a zend_string at once and then use RETVAL_STR.
- TSRMLS_CC is not needed, as you target 7.0+
- C style comments should be used

Added Travis-CI configuration