### PR TITLE
Fix #11: config.w32 is missing from 1.0.1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@ Casing fix config.m4
   <dir name="/">
    <file name="base58.c" role="src"/>
    <file name="config.m4" role="src"/>
+   <file name="config.w32" role="src"/>
    <file name="CREDITS" role="doc"/>
    <file name="LICENSE" role="doc"/>
    <file name="php_base58.h" role="src"/>


### PR DESCRIPTION
We need to list config.w32 as file in package.xml, so that it will be
contained in the releases.